### PR TITLE
Allowing for isset() on validator magic properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ use Behance\NBD\Validation\Services\ValidatorService;
 $validator = new ValidatorService();
 
 // Define a series of rules: field key, field name, and a pipe-separated sequence of validator rules (from list below)
-$validator->setRule( 'email',      'E-Mail',     'required|email' )
-          ->setRule( 'first_name', 'First Name', 'required|alpha' )
-          ->setRule( 'last_name',  'Last Name',  'required|alpha' );
+$validator->setRule( 'email',      'E-Mail',          'required|email' )
+          ->setRule( 'first_name', 'First Name',      'required|alpha' )
+          ->setRule( 'last_name',  'Last Name',       'required|alpha' )
+          ->setRule( 'middle',      'Middle Initial', 'alpha|maxLength[1]' );
 
 // Insert data to be validated
 $validator->setCageData( $_POST );
@@ -67,6 +68,9 @@ else {
   $email      = $validator->email;
   $first_name = $validator->first_name;
   $last_name  = $validator->last_name;
+
+  // You can check if a magic property exists using isset() whether or not it has passed validation.
+  $has_middle = isset( $validator->middle );
 
   // Or, retrieve valid fields as a key-value array
   $fields = $validator->getValidData(); // ex. [ 'email' => xxx, ... ],  will discard unvalidated/failed fields

--- a/src/Validation/Services/ValidatorService.php
+++ b/src/Validation/Services/ValidatorService.php
@@ -578,6 +578,21 @@ class ValidatorService implements ValidatorServiceInterface {
 
 
   /**
+   * Convenience function to allow for the checking of valid properties
+   *
+   * @param string $property  The field to check, as a property
+   *
+   * @return bool
+   */
+  public function __isset( $property ) {
+
+    //  We validate the logic and then check if it's actually set in the event that it's not truthy.
+    return $this->getValidatedField( $property ) || isset( $this->_valid_data[ $property ] );
+
+  } // __isset
+
+
+  /**
    * @throws BadMethodCallException  method is not supported
    */
   public function __set( $key, $value ) {

--- a/tests/Validation/Services/ValidatorServiceTest.php
+++ b/tests/Validation/Services/ValidatorServiceTest.php
@@ -1277,6 +1277,53 @@ class NBD_Validation_Services_ValidatorServiceTest extends PHPUnit_Framework_Tes
 
 
   /**
+   * @test
+   * @dataProvider issetOnFieldAsPropertyProvider
+   */
+  public function issetOnFieldAsProperty( $value, $rule, $outcome ) {
+
+    $data = [
+        'field_under_test' => $value
+    ];
+
+    $validator = new ValidatorService( $data );
+
+    $validator->setRule( 'field_under_test',   'Field Under Test',   $rule );
+
+    $validator->run();
+
+    $this->assertEquals( $outcome, isset( $validator->field_under_test ) );
+
+  } // issetOnFieldAsProperty
+
+
+  /**
+   * @test
+   * @dataProvider issetOnFieldAsPropertyBadProvider
+   */
+  public function issetOnFieldAsPropertyBad( $set_field, $check_field, $expected_exception ) {
+
+    $data = [
+        $set_field => 'Some data'
+    ];
+
+    $validator = new ValidatorService( $data );
+
+    $validator->setRule( $check_field, 'Field Under Test', 'required|minLength[1]' );
+
+    if ( $expected_exception !== 'Behance\NBD\Validation\Exceptions\Validator\NotRunException' ) {
+      $validator->run();
+    }
+
+    $this->setExpectedException( $expected_exception );
+
+    // Invocation
+    isset( $validator->$set_field );
+
+  } // issetOnFieldAsPropertyBad
+
+
+  /**
    * @return bool
    */
   public static function callbackIsIntPositive( $data ) {
@@ -1300,5 +1347,30 @@ class NBD_Validation_Services_ValidatorServiceTest extends PHPUnit_Framework_Tes
 
   } // callbackFailNoErrorAdded
 
+
+  /**
+   * @return array
+   */
+  public function issetOnFieldAsPropertyProvider() {
+
+    return [
+        [ 'Some text', 'required|minLength[1]', true ],
+        [ 'Some text', 'required|maxLength[1]', false ],
+        [ '0',         'required|range[0,1]',      true ]
+    ];
+
+  } // issetOnFieldAsPropertyProvider
+
+  /**
+   * @return array
+   */
+  public function issetOnFieldAsPropertyBadProvider() {
+
+    return [
+        [ 'field_name', 'field_name',    'Behance\NBD\Validation\Exceptions\Validator\NotRunException' ],
+        [ 'field_name', 'name_of_field', 'Behance\NBD\Validation\Exceptions\Validator\InvalidRuleException' ]
+    ];
+
+  } // issetOnFieldAsPropertyBadProvider
 
 } // NBD_Validation_Services_ValidatorServiceTest


### PR DESCRIPTION
Convenience which allows us to avoid having to call (and assign) `getValidatedData()` and then immediately call `isset()` on the result for the piece of data we need.

E.g., 
OLD:
```
$validator->run();
$valid_fields = $validator->getValidatedData(); // Too much work.
if ( isset( $valid_fields[ 'some_field' ] ) ) {
  $validator->some_field; // Do something.
}
```

vs NEW:
```
$validator->run();
if ( isset( $validator->some_field ) ) {
  $validator->some_field; // Do something.
}
```