### PR TITLE
Nullable Rule: allows a field to be reset via an empty string or `null`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $validator = new ValidatorService();
 $validator->setRule( 'email',      'E-Mail',          'required|email' )
           ->setRule( 'first_name', 'First Name',      'required|alpha' )
           ->setRule( 'last_name',  'Last Name',       'required|alpha' )
-          ->setRule( 'middle_i',   'Middle Initial',  'alpha|maxLength[1]' );
+          ->setRule( 'middle_i',   'Middle Initial',  'alpha|nullable|maxLength[1]' );
 
 // Insert data to be validated
 $validator->setCageData( $_POST );
@@ -127,6 +127,31 @@ Parameters are defined comma-separated inside brackets after rule:
 <tr><td>filter</td><td>filter[trim,md5]</td><td>1+</td><td>applies transformation of input, evaluating left to right, transformation is seen by subsequent rules and subsequent retrieval. Parameter can be any single-parameter defined function that returns a transformed result. In example, will trim(), then md5() input, which would be coded as md5( trim( $input ) );</td></tr>
 
 </table>
+
+
+#####Other Special rules:
+
+
+<table>
+<tr><th>Rule</th><th>Explanation</th></tr>
+<tr><td>required</td><td>The required rule checks if a field was passed into the validator. It does *not* validate the fields value and if it is empty or not.</td></tr>
+<tr><td>nullable</td><td>The nullable rule allows empty data to be passed to simulate clearing out a fields data. It accepts an empty string or `NULL` as valid input.</td></tr>
+</table>
+
+######Examples
+
+<table>
+  <tr><th>Case</th><th>Valid</th></tr>
+  <tr><td>required nullable, where key doesn’t exist</td><td>false</td></tr>
+  <tr><td>required nullable, where key exists but value is set to empty string/null</td><td>true</td></tr>
+  <tr><td>required nullable, where key is truth-y</td><td>true</td></tr>
+  <tr><td>optional nullable, where key doesn’t exist</td><td>true</td></tr>
+  <tr><td>optional nullable, where key exists but value is set to empty string/null</td><td>true</td></tr>
+  <tr><td>optional nullable, where key is truth-y</td><td>true</td></tr>
+</table>
+
+* "valid" cases still depend on the rest of the rule set
+* special rules cannot be used exclusive together or by themselves, they must be accompanied by other rules.
 
 
 #####Add custom named validators quickly and easily:

--- a/src/Validation/Interfaces/ValidatorServiceInterface.php
+++ b/src/Validation/Interfaces/ValidatorServiceInterface.php
@@ -94,6 +94,16 @@ interface ValidatorServiceInterface {
 
 
   /**
+   * Convenience function to check if $key has been defined as nullable or not.
+   *
+   * @param string $key
+   *
+   * @return bool
+   */
+  public function isFieldNullable( $key );
+
+
+  /**
    * Execute all validators on $this->_cage_data using setRule(s)
    *
    * @throws NotRunException           when no validators have previously been set

--- a/src/Validation/Rules/NullableRule.php
+++ b/src/Validation/Rules/NullableRule.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Behance\NBD\Validation\Rules;
+
+use Behance\NBD\Validation\Abstracts\CallbackRuleAbstract;
+
+class NullableRule extends CallbackRuleAbstract {
+
+  protected $_error_template = "%fieldname% is not a null value";
+
+  /**
+   * {@inheritDoc}
+   */
+  public function __construct() {
+
+    $closure = ( function( $data ) {
+      return ( $data === null || $data === '' );
+    } );
+
+    $this->setClosure( $closure );
+
+  } // __construct
+
+} // NullableRule

--- a/src/Validation/Services/ValidatorService.php
+++ b/src/Validation/Services/ValidatorService.php
@@ -106,13 +106,16 @@ class ValidatorService implements ValidatorServiceInterface {
    */
   public function setRule( $key, $fieldname, $rules ) {
 
-    $rules = ( is_array( $rules ) )
-             ? $rules
-             : explode( '|', $rules );
+    $special = $this->_getSpecialRules();
+    $rules   = ( is_array( $rules ) )
+               ? $rules
+               : explode( '|', $rules );
 
-    // IMPORTANT: simply having 'required' is not sufficient for a validator ruleset
-    if ( count( $rules ) === 1 && $rules[0] === self::RULE_REQUIRED ) {
-      throw new RuleRequirementException( "A valid ruleset for '{$key}' must more than just 'required'" );
+    // IMPORTANT: simply having 'required' and/or 'nullable' is not sufficient for a validator ruleset
+    if ( count( $rules ) === 1 && in_array( $rules[0], $special ) ) {
+      throw new RuleRequirementException( "A valid ruleset for '{$key}' must more than just '{$rules[0]}'" );
+    } elseif ( count( $rules ) === 2 && $rules == $special ) {
+      throw new RuleRequirementException( "A valid ruleset for '{$key}' must more than just 'required' and 'nullable'" );
     }
 
     $this->_rules[ $key ]       = $rules;

--- a/src/Validation/Services/ValidatorService.php
+++ b/src/Validation/Services/ValidatorService.php
@@ -106,9 +106,9 @@ class ValidatorService implements ValidatorServiceInterface {
    */
   public function setRule( $key, $fieldname, $rules ) {
 
-    $rules          = ( is_array( $rules ) )
-                      ? $rules
-                      : array_filter( explode( '|', $rules ) );
+    $rules = ( is_array( $rules ) )
+             ? $rules
+             : array_filter( explode( '|', $rules ) );
 
     if ( empty( $rules ) ) {
       throw new RuleRequirementException( 'No validation rules specified' );

--- a/tests/Validation/Services/ValidatorServiceTest.php
+++ b/tests/Validation/Services/ValidatorServiceTest.php
@@ -309,11 +309,11 @@ class NBD_Validation_Services_ValidatorServiceTest extends PHPUnit_Framework_Tes
         'required nullable, where key doesn’t exist'                           => [ 'expected' => false, 'rules' => 'required|nullable|Integer', 'data' => [ 'nope' => 1 ] ],
         'required nullable, where key exists but value is set to empty string' => [ 'expected' => true,  'rules' => 'required|nullable|Integer', 'data' => [ 'id'   => '' ] ],
         'required nullable, where key exists but value is set to null'         => [ 'expected' => true,  'rules' => 'required|nullable|Integer', 'data' => [ 'id'   => null ] ],
-        'required nullable, where key is set to truth-y'                       => [ 'expected' => true,  'rules' => 'required|nullable|Integer', 'data' => [ 'id'   => 1 ] ],
+        'required nullable, where key is truth-y'                              => [ 'expected' => true,  'rules' => 'required|nullable|Integer', 'data' => [ 'id'   => 1 ] ],
         'optional nullable, where key doesn’t exist'                           => [ 'expected' => true,  'rules' => 'nullable|Integer',          'data' => [ 'nope' => 1 ] ],
         'optional nullable, where key exists but value is set to empty string' => [ 'expected' => true,  'rules' => 'nullable|Integer',          'data' => [ 'id'   => '' ] ],
         'optional nullable, where key exists but value is set to null'         => [ 'expected' => true,  'rules' => 'nullable|Integer',          'data' => [ 'id'   => null ] ],
-        'optional nullable, where key is set to truth-y'                       => [ 'expected' => true,  'rules' => 'nullable|Integer',          'data' => [ 'id'   => 1 ] ],
+        'optional nullable, where key is truth-y'                              => [ 'expected' => true,  'rules' => 'nullable|Integer',          'data' => [ 'id'   => 1 ] ],
     ];
 
   } // specialRulesProvider
@@ -599,17 +599,32 @@ class NBD_Validation_Services_ValidatorServiceTest extends PHPUnit_Framework_Tes
 
 
   /**
+   * @return array
+   */
+  public function runOnlySpecialErrorProvider() {
+
+    return [
+        'only required'              => [ 'rules' => 'required' ],
+        'only nullable'              => [ 'rules' => 'nullable' ],
+        'both required and nullable' => [ 'rules' => 'required|nullable' ],
+    ];
+
+  } // runOnlySpecialErrorProvider
+
+
+  /**
    * @test
+   * @dataProvider runOnlySpecialErrorProvider
    * @expectedException  Behance\NBD\Validation\Exceptions\Validator\RuleRequirementException
    */
-  public function runOnlyRequiredError() {
+  public function runOnlySpecialError( $rules ) {
 
     $test = new ValidatorService();
 
-    $test->setRule( 'email', 'E-Mail', 'required' );
+    $test->setRule( 'email', 'E-Mail', $rules );
     $test->run();
 
-  } // runOnlyRequiredError
+  } // runOnlySpecialError
 
 
   /**

--- a/tests/Validation/Services/ValidatorServiceTest.php
+++ b/tests/Validation/Services/ValidatorServiceTest.php
@@ -43,6 +43,19 @@ class NBD_Validation_Services_ValidatorServiceTest extends PHPUnit_Framework_Tes
 
   /**
    * @test
+   * @expectedException  Behance\NBD\Validation\Exceptions\Validator\RuleRequirementException
+   */
+  public function setRuleEmptyRules() {
+
+    $test = new ValidatorService();
+
+    $test->setRule( 'email', 'E-Mail', '' );
+
+  } // setRuleEmptyRules
+
+
+  /**
+   * @test
    */
   public function setGetRule() {
 
@@ -388,7 +401,7 @@ class NBD_Validation_Services_ValidatorServiceTest extends PHPUnit_Framework_Tes
     $key       = 'email';
     $message   = 'a message goes here';
 
-    $validator->setRule( $key, '', '' )
+    $validator->setRule( $key, 'id', 'Integer' )
               ->addFieldFailure( $key, $message );
 
     $this->assertEquals( [ $key ], $validator->getFailedFields() );
@@ -416,7 +429,7 @@ class NBD_Validation_Services_ValidatorServiceTest extends PHPUnit_Framework_Tes
     $validator = new ValidatorService();
     $key       = 'email';
     $message   = 'a message goes here';
-    $rules[]   = [ 'email', '', '' ];
+    $rules[]   = [ 'email', 'id', 'Integer' ];
 
     $validator->setRules( $rules )
               ->addFieldFailure( $key, $message );
@@ -435,7 +448,7 @@ class NBD_Validation_Services_ValidatorServiceTest extends PHPUnit_Framework_Tes
     $key       = 'email';
     $message   = 'a message goes here';
 
-    $validator->setRule( $key, '', '' )
+    $validator->setRule( $key, 'id', 'Integer' )
               ->addFieldFailure( $key, $message );
 
     $this->assertTrue( $validator->isFieldFailed( $key ) );

--- a/tests/Validation/Services/ValidatorServiceTest.php
+++ b/tests/Validation/Services/ValidatorServiceTest.php
@@ -301,6 +301,39 @@ class NBD_Validation_Services_ValidatorServiceTest extends PHPUnit_Framework_Tes
 
 
   /**
+   * @return array
+   */
+  public function specialRulesProvider() {
+
+    return [
+        'required nullable, where key doesn’t exist'                           => [ 'expected' => false, 'rules' => 'required|nullable|Integer', 'data' => [ 'nope' => 1 ] ],
+        'required nullable, where key exists but value is set to empty string' => [ 'expected' => true,  'rules' => 'required|nullable|Integer', 'data' => [ 'id'   => '' ] ],
+        'required nullable, where key exists but value is set to null'         => [ 'expected' => true,  'rules' => 'required|nullable|Integer', 'data' => [ 'id'   => null ] ],
+        'required nullable, where key is set to truth-y'                       => [ 'expected' => true,  'rules' => 'required|nullable|Integer', 'data' => [ 'id'   => 1 ] ],
+        'optional nullable, where key doesn’t exist'                           => [ 'expected' => true,  'rules' => 'nullable|Integer',          'data' => [ 'nope' => 1 ] ],
+        'optional nullable, where key exists but value is set to empty string' => [ 'expected' => true,  'rules' => 'nullable|Integer',          'data' => [ 'id'   => '' ] ],
+        'optional nullable, where key exists but value is set to null'         => [ 'expected' => true,  'rules' => 'nullable|Integer',          'data' => [ 'id'   => null ] ],
+        'optional nullable, where key is set to truth-y'                       => [ 'expected' => true,  'rules' => 'nullable|Integer',          'data' => [ 'id'   => 1 ] ],
+    ];
+
+  } // specialRulesProvider
+
+
+  /**
+   * @test
+   * @dataProvider specialRulesProvider
+   */
+  public function specialRules( $expected, $rules, $data ) {
+
+    $validator = new ValidatorService( $data );
+    $validator->setRule( 'id', 'User ID', $rules );
+
+    $this->assertEquals( $expected, $validator->run() );
+
+  } // specialRules
+
+
+  /**
    * @test
    */
   public function isFieldRequiredFalse() {


### PR DESCRIPTION
`nullable` is another special rule like `required`. Nullable allows fields to be reset via an empty string `''` or `NULL`. If a field is `nullable`, and an empty string/`null` is passed, it will pass validation, and skip running the rest of the rules for the specified field.