### PR TITLE
RuleAbstract: Promote validator context extraction from MatchesRule to RuleAbstract

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,10 @@
     "license": "MIT",
     "authors": [
         {
+            "name": "Mark Dunphy",
+            "email": "dunphy@adobe.com"
+        },
+        {
             "name": "Jim DeLois",
             "email": "delois@adobe.com"
         },

--- a/src/Validation/Abstracts/RuleAbstract.php
+++ b/src/Validation/Abstracts/RuleAbstract.php
@@ -3,12 +3,14 @@
 namespace Behance\NBD\Validation\Abstracts;
 
 use Behance\NBD\Validation\Interfaces\RuleInterface;
+use Behance\NBD\Validation\Interfaces\ValidatorServiceInterface;
 use Behance\NBD\Validation\Exceptions\Validator\RuleRequirementException;
 
 abstract class RuleAbstract implements RuleInterface {
 
   // Names the key within context array where rule parameters are passed
   const KEY_CONTEXT_PARAMETERS = 'parameters';
+  const KEY_CONTEXT_VALIDATOR  = 'validator';
 
   // When defined, mandates how many parameters must be present to return from context parameters
   const REQUIRED_PARAM_COUNT   = false;
@@ -58,11 +60,10 @@ abstract class RuleAbstract implements RuleInterface {
    * When a REQUIRED_PARAM_COUNT constant is defined, requires that many
    * items from context parameters and returns them to the caller
    *
-   * @throws RuleRequirementException
-   *
    * @param array $context
    *
    * @return array
+   * @throws \Behance\NBD\Validation\Exceptions\Validator\RuleRequirementException
    */
   protected function _extractContextParameters( array $context ) {
 
@@ -80,5 +81,25 @@ abstract class RuleAbstract implements RuleInterface {
     return $context[ $key ];
 
   } // _extractContextParameters
+
+  /**
+   * Extracts a Validator from a given array context
+   *
+   * @param array $context
+   *
+   * @return \Behance\NBD\Validation\Interfaces\ValidatorServiceInterface
+   * @throws \Behance\NBD\Validation\Exceptions\Validator\RuleRequirementException
+   */
+  protected function _extractContextValidator( array $context ) {
+
+    $key = static::KEY_CONTEXT_VALIDATOR;
+
+    if ( empty( $context[ $key ] ) || !( $context[ $key ] instanceof ValidatorServiceInterface ) ) {
+      throw new RuleRequirementException( "Validator required for '" . get_class( $this ) . "'" );
+    }
+
+    return $context[ $key ];
+
+  } // _extractContextValidator
 
 } // RuleAbstract

--- a/src/Validation/Rules/MatchesRule.php
+++ b/src/Validation/Rules/MatchesRule.php
@@ -25,7 +25,7 @@ class MatchesRule extends CallbackRuleAbstract {
 
       list( $other_field_key ) = $this->_extractContextParameters( $context );
 
-      $other_field = $this->_getValidatorFromContext( $context )->getCageDataValue( $other_field_key );
+      $other_field = $this->_extractContextValidator( $context )->getCageDataValue( $other_field_key );
 
       if ( $data === null || $other_field === null ) {
         return false;
@@ -48,26 +48,10 @@ class MatchesRule extends CallbackRuleAbstract {
     list( $other_field_key ) = $this->_extractContextParameters( $context );
 
     // Insert 'otherfield' into context array
-    $context['otherfield'] = $this->_getValidatorFromContext( $context )->getFieldname( $other_field_key );
+    $context['otherfield'] = $this->_extractContextValidator( $context )->getFieldname( $other_field_key );
 
     return $context;
 
   } // convertFormattingContext
-
-
-  /**
-   * @param array $context
-   *
-   * @return Behance\NBD\Validator\Interfaces\ValidatorServiceInterface
-   */
-  private function _getValidatorFromContext( array $context ) {
-
-    if ( empty( $context['validator'] ) || !( $context['validator'] instanceof ValidatorServiceInterface ) ) {
-      throw new RuleRequirementException( "Validator required as context for '" . __CLASS__ . "'" );
-    }
-
-    return $context['validator'];
-
-  } // _getValidatorFromContext
 
 } // MatchesRule


### PR DESCRIPTION
Other rules could want to safely extract the `ValidatorService` from the context. This PR just promotes that functionality from `MatchesRule` to `RuleAbstract`

Reviewers:
- @jimdelois 
- @bryanlatten 