### PR TITLE
Allow non-ASCII characters in URLs

### DIFF
--- a/src/Validation/Rules/UrlRule.php
+++ b/src/Validation/Rules/UrlRule.php
@@ -9,7 +9,7 @@ use Behance\NBD\Validation\Abstracts\RegexRuleAbstract;
  */
 class UrlRule extends RegexRuleAbstract {
 
-  protected $_pattern = '/^((?:https?):\/\/)?(?:(?:(?:[\w\.\-\+!$&\'\(\)*\+,;=_]|%[0-9a-f]{2})+:)*(?:[\w\.\-\+%!$&\'\(\)*\+,;=_]|%[0-9a-f]{2})+@)?(?:[A-Za-z0-9_\-]+\.)(?:[A-Za-z0-9_\-\.])+(?::[0-9]+)?(?:[\/|\?](?:[\w#!:\.\?\+=&@$\'~*,;_\/\(\)\[\]\-]|%[0-9a-f]{2})*)?$/ui';
+  protected $_pattern = '/^((?:https?):\/\/)?(?:(?:(?:[\w\.\-\+!$&\'\(\)*\+,;=_]|%[0-9a-f]{2})+:)*(?:[\w\.\-\+%!$&\'\(\)*\+,;=_]|%[0-9a-f]{2})+@)?(?:[A-Za-z0-9\x{00A1}-\x{FFFF}_\-]+\.)(?:[A-Za-z0-9\x{00A1}-\x{FFFF}_\-\.])+(?::[0-9]+)?(?:[\/|\?](?:[\w#!:\.\?\+=&@$\'~*,;_\/\(\)\[\]\-]|%[0-9a-f]{2})*)?$/ui';
 
   /**
    * @inheritDoc
@@ -20,7 +20,7 @@ class UrlRule extends RegexRuleAbstract {
       return false;
     }
 
-    return in_array( parse_url( $data, PHP_URL_SCHEME ), ['', 'http', 'https', 'mailto'] );
+    return in_array( parse_url( $data, PHP_URL_SCHEME ), [ '', 'http', 'https', 'mailto' ] );
 
   } // isValid
 

--- a/tests/Validation/Rules/UrlRuleTest.php
+++ b/tests/Validation/Rules/UrlRuleTest.php
@@ -28,12 +28,20 @@ class UrlRuleTest extends \PHPUnit\Framework\TestCase {
     return [
         // allowed
         [ 'www.google.com', true ],
+        [ 'behance.net', true ],
         [ 'bob@behance.com', true ],
         [ 'mailto:dave@behance.com', true ],
         [ 'http://www.google.com', true ],
         [ 'https://www.google.com', true ],
         [ 'www.google.com?a=1&b=2#fun', true ],
         [ 'www.behance.net/job/Multimedia-Designer%2C-Senior', true ], // testing "%2C"
+        // allowed: Punycode
+        [ 'http://punycode.XN--TCKWE', true ],
+        // allowed: Non-Latin characters
+        [ 'http://全国温泉ガイド.jp', true ],
+        [ 'http://उदाहरण.परीक्षा', true ],
+        [ 'http://минобрнауки.рф', true ],
+        [ 'минобрнауки.рф', true ],
         // disallowed: protocol relative
         [ '//www.google.com', false ],
         [ '//www.google.co.uk', false ],


### PR DESCRIPTION
It looks like link URL validation in the Portfolio Editor runs through here. So we need to update the URL validation rule to allow non-Latin characters in URLs.

This is 1 of 3 updates needed for https://app.zenhub.com/workspace/o/adobe-community/issues/issues/23427. There are also changes needed in Core and [BeFF](https://github.com/behance/BeFF/pull/200).